### PR TITLE
Implement soft delete

### DIFF
--- a/src/actions/delete-appointment/index.tsx
+++ b/src/actions/delete-appointment/index.tsx
@@ -34,7 +34,8 @@ export const deleteAppointment = protectedWithClinicActionClient
     }
 
     await db
-      .delete(appointmentsTable)
+      .update(appointmentsTable)
+      .set({ deletedAt: new Date() })
       .where(eq(appointmentsTable.id, parsedInput.id));
     revalidatePath("/appointments");
 

--- a/src/actions/delete-doctor/index.tsx
+++ b/src/actions/delete-doctor/index.tsx
@@ -39,8 +39,11 @@ export const deleteDoctor = protectedWithClinicActionClient
       throw new Error("Doctor doesn't belong to the clinic");
     }
 
-    // deletando o doctor
-    await db.delete(doctorsTable).where(eq(doctorsTable.id, parsedInput.id));
+    // faz o soft delete do doctor marcando a data de exclusão
+    await db
+      .update(doctorsTable)
+      .set({ deletedAt: new Date() })
+      .where(eq(doctorsTable.id, parsedInput.id));
     revalidatePath("/doctors"); // após a deleção ele recarrega a página
 
     return { success: true };

--- a/src/actions/delete-patient/index.tsx
+++ b/src/actions/delete-patient/index.tsx
@@ -33,7 +33,10 @@ export const deletePatient = protectedWithClinicActionClient
       throw new Error("Patient doesn't belong to the clinic");
     }
 
-    await db.delete(patientsTable).where(eq(patientsTable.id, parsedInput.id));
+    await db
+      .update(patientsTable)
+      .set({ deletedAt: new Date() })
+      .where(eq(patientsTable.id, parsedInput.id));
     revalidatePath("/patients");
 
     return { success: true };

--- a/src/actions/get-available-times/index.tsx
+++ b/src/actions/get-available-times/index.tsx
@@ -3,7 +3,7 @@
 import dayjs from "dayjs";
 import timezone from "dayjs/plugin/timezone";
 import utc from "dayjs/plugin/utc";
-import { eq } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
 import { z } from "zod";
 
 import { db } from "@/db";
@@ -30,7 +30,10 @@ export const getAvailableTimes = protectedWithClinicActionClient
   )
   .action(async ({ parsedInput, ctx }) => {
     const doctor = await db.query.doctorsTable.findFirst({
-      where: eq(doctorsTable.id, parsedInput.doctorId),
+      where: and(
+        eq(doctorsTable.id, parsedInput.doctorId),
+        isNull(doctorsTable.deletedAt),
+      ),
     });
 
     if (!doctor) {
@@ -58,7 +61,10 @@ export const getAvailableTimes = protectedWithClinicActionClient
 
     // caso o medico tenha disponibilidade nesse dia, nó pegaremos todos agendamento do médico
     const appointments = await db.query.appointmentsTable.findMany({
-      where: eq(appointmentsTable.doctorId, parsedInput.doctorId),
+      where: and(
+        eq(appointmentsTable.doctorId, parsedInput.doctorId),
+        isNull(appointmentsTable.deletedAt),
+      ),
     });
 
     // e aqui pegamos todos os agendamentos do médico nesse dia, apenas do dia selecionado

--- a/src/app/(protected)/appointments/page copy.tsx
+++ b/src/app/(protected)/appointments/page copy.tsx
@@ -1,4 +1,4 @@
-import { eq } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 
@@ -45,13 +45,22 @@ const AppointmentsPage = async () => {
   // o "promise.all" é usado para executar as consultas em paralelo, então todas essas querys no banco de dados serão executadas ao mesmo tempo, nos dando mais performance
   const [patients, doctors, appointments] = await Promise.all([
     db.query.patientsTable.findMany({
-      where: eq(patientsTable.clinicId, session.user.clinic.id),
+      where: and(
+        eq(patientsTable.clinicId, session.user.clinic.id),
+        isNull(patientsTable.deletedAt),
+      ),
     }),
     db.query.doctorsTable.findMany({
-      where: eq(doctorsTable.clinicId, session.user.clinic.id),
+      where: and(
+        eq(doctorsTable.clinicId, session.user.clinic.id),
+        isNull(doctorsTable.deletedAt),
+      ),
     }),
     db.query.appointmentsTable.findMany({
-      where: eq(appointmentsTable.clinicId, session.user.clinic.id),
+      where: and(
+        eq(appointmentsTable.clinicId, session.user.clinic.id),
+        isNull(appointmentsTable.deletedAt),
+      ),
       with: {
         patient: true,
         doctor: true,

--- a/src/app/(protected)/appointments/page.tsx
+++ b/src/app/(protected)/appointments/page.tsx
@@ -1,4 +1,4 @@
-import { eq } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
 import { headers } from "next/headers";
 
 import { DataTable } from "@/components/ui/data-table";
@@ -32,13 +32,22 @@ const AppointmentsPage = async () => {
   const [patients, doctors, appointments] = await Promise.all([
     db.query.patientsTable.findMany({
       // Para que ele não de erro achando que a session é null (sneod que ele nem renderiza o componente se for nulo), usamos "!" para forçar o typescript a aceitar que a session não é nula
-      where: eq(patientsTable.clinicId, session!.user.clinic!.id),
+      where: and(
+        eq(patientsTable.clinicId, session!.user.clinic!.id),
+        isNull(patientsTable.deletedAt),
+      ),
     }),
     db.query.doctorsTable.findMany({
-      where: eq(doctorsTable.clinicId, session!.user.clinic!.id),
+      where: and(
+        eq(doctorsTable.clinicId, session!.user.clinic!.id),
+        isNull(doctorsTable.deletedAt),
+      ),
     }),
     db.query.appointmentsTable.findMany({
-      where: eq(appointmentsTable.clinicId, session!.user.clinic!.id),
+      where: and(
+        eq(appointmentsTable.clinicId, session!.user.clinic!.id),
+        isNull(appointmentsTable.deletedAt),
+      ),
       with: {
         patient: true,
         doctor: true,

--- a/src/app/(protected)/doctors/page.tsx
+++ b/src/app/(protected)/doctors/page.tsx
@@ -1,4 +1,4 @@
-import { eq } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
 import { headers } from "next/headers";
 
 import {
@@ -24,7 +24,10 @@ const DoctorsPage = async () => {
   });
 
   const doctors = await db.query.doctorsTable.findMany({
-    where: eq(doctorsTable.clinicId, session!.user.clinic!.id),
+    where: and(
+      eq(doctorsTable.clinicId, session!.user.clinic!.id),
+      isNull(doctorsTable.deletedAt),
+    ),
   });
 
   return (

--- a/src/app/(protected)/patients/page.tsx
+++ b/src/app/(protected)/patients/page.tsx
@@ -1,4 +1,4 @@
-import { eq } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
 import { headers } from "next/headers";
 
 import { DataTable } from "@/components/ui/data-table";
@@ -25,7 +25,10 @@ const PatientsPage = async () => {
   });
 
   const patients = await db.query.patientsTable.findMany({
-    where: eq(patientsTable.clinicId, session!.user.clinic!.id),
+    where: and(
+      eq(patientsTable.clinicId, session!.user.clinic!.id),
+      isNull(patientsTable.deletedAt),
+    ),
   });
 
   return (


### PR DESCRIPTION
## Summary
- switch doctor, patient and appointment deletions to soft delete
- ignore soft-deleted rows when fetching data for pages or dashboard
- filter deleted items in available time lookup

## Testing
- `npm run lint` *(fails: simple-import-sort errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68463f40accc833095b1a6c65e0cc955