### PR TITLE
Implement email verification checks

### DIFF
--- a/src/app/(protected)/appointments/_components/add-appointment-button.tsx
+++ b/src/app/(protected)/appointments/_components/add-appointment-button.tsx
@@ -2,10 +2,12 @@
 
 import { Plus } from "lucide-react";
 import { useState } from "react";
+import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogTrigger } from "@/components/ui/dialog";
 import { doctorsTable, patientsTable } from "@/db/schema";
+import { useEmailVerified } from "@/hooks/use-email-verified";
 
 import { AddAppointmentForm } from "./add-appointment-form";
 
@@ -19,11 +21,20 @@ const AddAppointmentButton = ({
   doctors,
 }: AddAppointmentButtonProps) => {
   const [isOpen, setIsOpen] = useState(false);
+  const emailVerified = useEmailVerified();
+
+  const handleOpenChange = (open: boolean) => {
+    if (open && !emailVerified) {
+      toast.error("Verify your email to add an appointment");
+      return;
+    }
+    setIsOpen(open);
+  };
 
   return (
-    <Dialog open={isOpen} onOpenChange={setIsOpen}>
+    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
       <DialogTrigger asChild>
-        <Button>
+        <Button disabled={!emailVerified}>
           <Plus />
           Add new Appointment
         </Button>

--- a/src/app/(protected)/doctors/_components/add-doctor-button.tsx
+++ b/src/app/(protected)/doctors/_components/add-doctor-button.tsx
@@ -2,19 +2,30 @@
 
 import { Plus } from "lucide-react";
 import { useState } from "react";
+import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogTrigger } from "@/components/ui/dialog";
+import { useEmailVerified } from "@/hooks/use-email-verified";
 
 import UpsertDoctorForm from "./upsert-doctor-form";
 
 const AddDoctorButton = () => {
   const [isOpen, setIsOpen] = useState(false);
+  const emailVerified = useEmailVerified();
+
+  const handleOpenChange = (open: boolean) => {
+    if (open && !emailVerified) {
+      toast.error("Verify your email to add a doctor");
+      return;
+    }
+    setIsOpen(open);
+  };
 
   return (
-    <Dialog open={isOpen} onOpenChange={setIsOpen}>
+    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
       <DialogTrigger asChild>
-        <Button>
+        <Button disabled={!emailVerified}>
           <Plus />
           Add new doctor
         </Button>

--- a/src/app/(protected)/patients/_components/add-patients-button.tsx
+++ b/src/app/(protected)/patients/_components/add-patients-button.tsx
@@ -2,6 +2,7 @@
 
 import { Plus } from "lucide-react";
 import { useState } from "react";
+import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -11,16 +12,26 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
+import { useEmailVerified } from "@/hooks/use-email-verified";
 
 import { UpsertPatientForm } from "./upsert-patient-form";
 
 export function AddPatientButton() {
   const [isOpen, setIsOpen] = useState(false);
+  const emailVerified = useEmailVerified();
+
+  const handleOpenChange = (open: boolean) => {
+    if (open && !emailVerified) {
+      toast.error("Verify your email to add a patient");
+      return;
+    }
+    setIsOpen(open);
+  };
 
   return (
-    <Dialog open={isOpen} onOpenChange={setIsOpen}>
+    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
       <DialogTrigger asChild>
-        <Button>
+        <Button disabled={!emailVerified}>
           <Plus className="mr-2 h-4 w-4" />
           Add Patient
         </Button>

--- a/src/app/authentication/_components/sign-in-form.tsx
+++ b/src/app/authentication/_components/sign-in-form.tsx
@@ -27,6 +27,7 @@ import {
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { authClient } from "@/lib/auth-client";
+import { signIn } from "@/services/auth";
 
 const loginSchema = z.object({
   email: z.string().trim().email({ message: "Invalid email address" }),
@@ -48,7 +49,7 @@ const SignInForm = () => {
 
   // 2. Define a submit handler.
   const handleSubmit = async (values: z.infer<typeof loginSchema>) => {
-    await authClient.signIn.email(
+    await signIn(
       {
         email: values.email,
         password: values.password,

--- a/src/app/authentication/_components/sign-up-form.tsx
+++ b/src/app/authentication/_components/sign-up-form.tsx
@@ -25,7 +25,7 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
-import { authClient } from "@/lib/auth-client";
+import { signUp } from "@/services/auth";
 
 const registerSchema = z.object({
   name: z.string().trim().min(1, { message: "Name is required" }),
@@ -48,14 +48,11 @@ const SignUpForm = () => {
   });
 
   async function onSubmit(values: z.infer<typeof registerSchema>) {
-    // https://www.better-auth.com/docs/basic-usage#sign-up
-    await authClient.signUp.email(
+    await signUp(
       {
         email: values.email,
         password: values.password,
         name: values.name,
-        // ele só é chamado depois que o email do usuário é validado
-        // callbackURL: "/dashboard", // redireciona para a dashboard apos o sign up
       },
       {
         onSuccess: () => {

--- a/src/hooks/use-email-verified.ts
+++ b/src/hooks/use-email-verified.ts
@@ -1,0 +1,6 @@
+import { authClient } from "@/lib/auth-client";
+
+export function useEmailVerified() {
+  const session = authClient.useSession();
+  return !!session?.data?.user?.emailVerified;
+}

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,0 +1,28 @@
+import { authClient } from "@/lib/auth-client";
+
+export function signUp(
+  values: { name: string; email: string; password: string },
+  options?: Parameters<typeof authClient.signUp.email>[1],
+) {
+  return authClient.signUp.email(
+    {
+      email: values.email,
+      password: values.password,
+      name: values.name,
+    },
+    options,
+  );
+}
+
+export function signIn(
+  values: { email: string; password: string },
+  options?: Parameters<typeof authClient.signIn.email>[1],
+) {
+  return authClient.signIn.email(
+    {
+      email: values.email,
+      password: values.password,
+    },
+    options,
+  );
+}


### PR DESCRIPTION
## Summary
- add auth service functions
- add hook to check if email is verified
- use new service in sign in and sign up forms
- restrict creating doctors, patients and appointments until email is verified

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68471399dda08330863b27a39faa2471