### PR TITLE
Add Alpha auth pages using React Query

### DIFF
--- a/src/app/(protected)/_components/app-sidebar.tsx
+++ b/src/app/(protected)/_components/app-sidebar.tsx
@@ -3,11 +3,11 @@
 import {
   CalendarDays,
   Gem,
+  KeyRound,
   LayoutDashboard,
   LogOut,
   Stethoscope,
   UsersRound,
-  KeyRound,
 } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";

--- a/src/app/auth/alph-signin/page.tsx
+++ b/src/app/auth/alph-signin/page.tsx
@@ -1,0 +1,23 @@
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
+
+import { auth } from "@/lib/auth";
+
+import { AlphSignInForm } from "../alph/_components/alph-signin-form";
+
+const AlphSignInPage = async () => {
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (session?.user) {
+    redirect("/dashboard");
+  }
+
+  return (
+    <div className="flex h-screen w-screen items-center justify-center">
+      <div className="w-[400px]">
+        <AlphSignInForm />
+      </div>
+    </div>
+  );
+};
+
+export default AlphSignInPage;

--- a/src/app/auth/alph-signup/page.tsx
+++ b/src/app/auth/alph-signup/page.tsx
@@ -1,0 +1,23 @@
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
+
+import { auth } from "@/lib/auth";
+
+import { AlphSignUpForm } from "../alph/_components/alph-signup-form";
+
+const AlphSignUpPage = async () => {
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (session?.user) {
+    redirect("/dashboard");
+  }
+
+  return (
+    <div className="flex h-screen w-screen items-center justify-center">
+      <div className="w-[400px]">
+        <AlphSignUpForm />
+      </div>
+    </div>
+  );
+};
+
+export default AlphSignUpPage;

--- a/src/app/auth/alph/_components/alph-signin-form.tsx
+++ b/src/app/auth/alph/_components/alph-signin-form.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useMutation } from "@tanstack/react-query";
+import { Loader2 } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+import { z } from "zod";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { authClient } from "@/lib/auth-client";
+import { signIn } from "@/services/auth";
+
+import { AlphSocialLoginButton } from "./alph-social-login-button";
+
+const loginSchema = z.object({
+  email: z.string().trim().email({ message: "Invalid email address" }),
+  password: z.string().trim().min(8, { message: "Password must be at least 8 characters" }),
+});
+
+export function AlphSignInForm() {
+  const router = useRouter();
+  const form = useForm<z.infer<typeof loginSchema>>({
+    resolver: zodResolver(loginSchema),
+    defaultValues: { email: "", password: "" },
+  });
+
+  const mutation = useMutation({
+    mutationFn: (values: z.infer<typeof loginSchema>) =>
+      signIn({ email: values.email, password: values.password }),
+    onSuccess: () => {
+      router.push("/dashboard");
+    },
+    onError: () => {
+      toast.error("Email or password is invalid");
+    },
+  });
+
+  const onSubmit = (values: z.infer<typeof loginSchema>) => {
+    mutation.mutate(values);
+  };
+
+  const handleGoogle = async () => {
+    await authClient.signIn.social({ provider: "google", callbackURL: "/dashboard", scopes: ["email", "profile"] });
+  };
+
+  return (
+    <Card className="w-full shadow-2xl border-0">
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+          <CardHeader>
+            <CardTitle className="text-2xl font-semibold text-center">Sign in to your account</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <FormField
+              control={form.control}
+              name="email"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Email</FormLabel>
+                  <FormControl>
+                    <Input type="email" placeholder="you@example.com" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="password"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Password</FormLabel>
+                  <FormControl>
+                    <Input type="password" placeholder="********" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <Button type="submit" className="w-full h-12 bg-blue-600 hover:bg-blue-700" disabled={mutation.isPending}>
+              {mutation.isPending ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" /> Signing in...
+                </>
+              ) : (
+                "Sign in"
+              )}
+            </Button>
+            <div className="relative py-2">
+              <div className="absolute inset-0 flex items-center">
+                <span className="w-full border-t" />
+              </div>
+              <div className="relative flex justify-center text-xs uppercase">
+                <span className="bg-white px-2 text-muted-foreground">Or</span>
+              </div>
+            </div>
+            <div className="space-y-3">
+              <AlphSocialLoginButton provider="google" onClick={handleGoogle} />
+            </div>
+          </CardContent>
+        </form>
+      </Form>
+    </Card>
+  );
+}

--- a/src/app/auth/alph/_components/alph-signup-form.tsx
+++ b/src/app/auth/alph/_components/alph-signup-form.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useMutation } from "@tanstack/react-query";
+import { Loader2 } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+import { z } from "zod";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { signUp } from "@/services/auth";
+
+const registerSchema = z.object({
+  name: z.string().trim().min(1, { message: "Name is required" }),
+  email: z.string().trim().email({ message: "Invalid email address" }),
+  password: z.string().trim().min(8, { message: "Password must be at least 8 characters" }),
+});
+
+export function AlphSignUpForm() {
+  const router = useRouter();
+  const form = useForm<z.infer<typeof registerSchema>>({
+    resolver: zodResolver(registerSchema),
+    defaultValues: { name: "", email: "", password: "" },
+  });
+
+  const mutation = useMutation({
+    mutationFn: (values: z.infer<typeof registerSchema>) =>
+      signUp({ name: values.name, email: values.email, password: values.password }),
+    onSuccess: () => {
+      router.push("/dashboard");
+    },
+    onError: (ctx: { error?: { code?: string } }) => {
+      if (ctx?.error?.code === "USER_ALREADY_EXISTS") {
+        toast.error("E-mail already registered");
+      } else {
+        toast.error("Failed to create account");
+      }
+    },
+  });
+
+  const onSubmit = (values: z.infer<typeof registerSchema>) => {
+    mutation.mutate(values);
+  };
+
+  return (
+    <Card className="w-full shadow-2xl border-0">
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+          <CardHeader>
+            <CardTitle className="text-2xl font-semibold text-center">Create your account</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <FormField
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Name</FormLabel>
+                  <FormControl>
+                    <Input placeholder="John Doe" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="email"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Email</FormLabel>
+                  <FormControl>
+                    <Input type="email" placeholder="you@example.com" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="password"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Password</FormLabel>
+                  <FormControl>
+                    <Input type="password" placeholder="********" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <Button type="submit" className="w-full h-12 bg-blue-600 hover:bg-blue-700" disabled={mutation.isPending}>
+              {mutation.isPending ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" /> Creating account...
+                </>
+              ) : (
+                "Create account"
+              )}
+            </Button>
+          </CardContent>
+        </form>
+      </Form>
+    </Card>
+  );
+}

--- a/src/app/auth/alph/_components/alph-social-login-button.tsx
+++ b/src/app/auth/alph/_components/alph-social-login-button.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { Building,Chrome, Key } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+
+interface SocialLoginButtonProps {
+  provider: "google" | "passkey" | "sso";
+  onClick: () => void;
+}
+
+export function AlphSocialLoginButton({ provider, onClick }: SocialLoginButtonProps) {
+  const config = {
+    google: {
+      icon: <Chrome className="h-4 w-4" />, text: "Sign in with Google",
+    },
+    passkey: {
+      icon: <Key className="h-4 w-4" />, text: "Sign in with passkey",
+    },
+    sso: {
+      icon: <Building className="h-4 w-4" />, text: "Sign in with SSO",
+    },
+  }[provider];
+
+  return (
+    <Button type="button" variant="outline" onClick={onClick} className="w-full h-12 justify-center gap-2">
+      {config.icon}
+      {config.text}
+    </Button>
+  );
+}

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -1,10 +1,10 @@
 "use client"
 
-import * as React from "react"
 import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
+import * as React from "react"
 
-import { cn } from "@/lib/utils"
 import { buttonVariants } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
 
 function AlertDialog({
   ...props
@@ -144,14 +144,14 @@ function AlertDialogCancel({
 
 export {
   AlertDialog,
-  AlertDialogPortal,
-  AlertDialogOverlay,
-  AlertDialogTrigger,
-  AlertDialogContent,
-  AlertDialogHeader,
-  AlertDialogFooter,
-  AlertDialogTitle,
-  AlertDialogDescription,
   AlertDialogAction,
   AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogOverlay,
+  AlertDialogPortal,
+  AlertDialogTitle,
+  AlertDialogTrigger,
 }

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,6 +1,6 @@
-import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
 import { cva, type VariantProps } from "class-variance-authority"
+import * as React from "react"
 
 import { cn } from "@/lib/utils"
 

--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -345,9 +345,9 @@ function getPayloadConfigFromPayload(
 
 export {
   ChartContainer,
-  ChartTooltip,
-  ChartTooltipContent,
   ChartLegend,
   ChartLegendContent,
   ChartStyle,
+  ChartTooltip,
+  ChartTooltipContent,
 }

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,8 +1,8 @@
 "use client"
 
-import * as React from "react"
 import * as DialogPrimitive from "@radix-ui/react-dialog"
 import { XIcon } from "lucide-react"
+import * as React from "react"
 
 import { cn } from "@/lib/utils"
 

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -1,8 +1,8 @@
 "use client"
 
-import * as React from "react"
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"
 import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react"
+import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
@@ -240,18 +240,18 @@ function DropdownMenuSubContent({
 
 export {
   DropdownMenu,
-  DropdownMenuPortal,
-  DropdownMenuTrigger,
+  DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuGroup,
-  DropdownMenuLabel,
   DropdownMenuItem,
-  DropdownMenuCheckboxItem,
+  DropdownMenuLabel,
+  DropdownMenuPortal,
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
   DropdownMenuSeparator,
   DropdownMenuShortcut,
   DropdownMenuSub,
-  DropdownMenuSubTrigger,
   DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
 }

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -1,20 +1,20 @@
 "use client"
 
-import * as React from "react"
 import * as LabelPrimitive from "@radix-ui/react-label"
 import { Slot } from "@radix-ui/react-slot"
+import * as React from "react"
 import {
   Controller,
-  FormProvider,
-  useFormContext,
-  useFormState,
   type ControllerProps,
   type FieldPath,
   type FieldValues,
+  FormProvider,
+  useFormContext,
+  useFormState,
 } from "react-hook-form"
 
-import { cn } from "@/lib/utils"
 import { Label } from "@/components/ui/label"
+import { cn } from "@/lib/utils"
 
 const Form = FormProvider
 
@@ -156,12 +156,12 @@ function FormMessage({ className, ...props }: React.ComponentProps<"p">) {
 }
 
 export {
-  useFormField,
   Form,
-  FormItem,
-  FormLabel,
   FormControl,
   FormDescription,
-  FormMessage,
   FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+  useFormField,
 }

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,7 +1,7 @@
 "use client"
 
-import * as React from "react"
 import * as LabelPrimitive from "@radix-ui/react-label"
+import * as React from "react"
 
 import { cn } from "@/lib/utils"
 

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -1,7 +1,7 @@
 "use client"
 
-import * as React from "react"
 import * as ProgressPrimitive from "@radix-ui/react-progress"
+import * as React from "react"
 
 import { cn } from "@/lib/utils"
 

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,8 +1,8 @@
 "use client"
 
-import * as React from "react"
 import * as SelectPrimitive from "@radix-ui/react-select"
 import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react"
+import * as React from "react"
 
 import { cn } from "@/lib/utils"
 

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -1,7 +1,7 @@
 "use client"
 
-import * as React from "react"
 import * as SeparatorPrimitive from "@radix-ui/react-separator"
+import * as React from "react"
 
 import { cn } from "@/lib/utils"
 

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -1,8 +1,8 @@
 "use client"
 
-import * as React from "react"
 import * as SheetPrimitive from "@radix-ui/react-dialog"
 import { XIcon } from "lucide-react"
+import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
@@ -129,11 +129,11 @@ function SheetDescription({
 
 export {
   Sheet,
-  SheetTrigger,
   SheetClose,
   SheetContent,
-  SheetHeader,
-  SheetFooter,
-  SheetTitle,
   SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
 }

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -106,11 +106,11 @@ function TableCaption({
 
 export {
   Table,
-  TableHeader,
   TableBody,
+  TableCaption,
+  TableCell,
   TableFooter,
   TableHead,
+  TableHeader,
   TableRow,
-  TableCell,
-  TableCaption,
 }

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,7 +1,7 @@
 "use client"
 
-import * as React from "react"
 import * as TabsPrimitive from "@radix-ui/react-tabs"
+import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
@@ -63,4 +63,4 @@ function TabsContent({
   )
 }
 
-export { Tabs, TabsList, TabsTrigger, TabsContent }
+export { Tabs, TabsContent,TabsList, TabsTrigger }

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -1,7 +1,7 @@
 "use client"
 
-import * as React from "react"
 import * as TooltipPrimitive from "@radix-ui/react-tooltip"
+import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
@@ -58,4 +58,4 @@ function TooltipContent({
   )
 }
 
-export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }
+export { Tooltip, TooltipContent, TooltipProvider,TooltipTrigger }

--- a/src/db/schema/appointments.ts
+++ b/src/db/schema/appointments.ts
@@ -1,4 +1,5 @@
 import { integer, pgTable, timestamp, uuid } from "drizzle-orm/pg-core";
+
 import { doctors } from "./doctors";
 import { patients } from "./patients";
 


### PR DESCRIPTION
## Summary
- add alph sign-in and sign-up pages
- create AlphSignInForm and AlphSignUpForm using React Query and Zod
- add social login button component
- fix lint issues across UI components

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6848446260a883308954534cf44a7c4f