### PR TITLE
Fix session fetch errors with new relations

### DIFF
--- a/src/app/auth/reset-password/_components/verify-step.tsx
+++ b/src/app/auth/reset-password/_components/verify-step.tsx
@@ -50,7 +50,7 @@ export function VerifyStep({ email, setStep }: VerifyStepProps) {
           <CardDescription>
             If <strong>{email}</strong> matches a registered address, you will
             receive an email with password reset instructions. <br /> <br />
-            If you haven't received an email within 5 minutes, check your spam
+            If you haven&apos;t received an email within 5 minutes, check your spam
             folder,{" "}
             <button
               onClick={() => mutation.mutate()}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -398,6 +398,13 @@ export const usersToClinicsTableRelations = relations(
   }),
 );
 
+export const sessionsTableRelations = relations(sessionsTable, ({ one }) => ({
+  user: one(usersTable, {
+    fields: [sessionsTable.userId],
+    references: [usersTable.id],
+  }),
+}));
+
 export const accountsTableRelations = relations(accountsTable, ({ one }) => ({
   user: one(usersTable, {
     fields: [accountsTable.userId],

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -2,7 +2,7 @@
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { customSession } from "better-auth/plugins";
-import { eq, isNull } from "drizzle-orm";
+import { eq, gt } from "drizzle-orm";
 
 import { db } from "@/db";
 // pegando todos os schemas que estão sendo exportados lá de "schemas"
@@ -108,7 +108,7 @@ export const auth = betterAuth({
               },
             },
           },
-          where: isNull(sessionsTable),
+          where: gt(sessionsTable.expiresAt, new Date()),
         });
       }
       return {


### PR DESCRIPTION
## Summary
- add missing session-to-user relation
- query only active sessions
- fix unescaped text in verification step

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684b581920c483308452ac2a330ad629