### PR TITLE
Add email verification flow

### DIFF
--- a/src/app/api/auth/email/resend-verification/route.ts
+++ b/src/app/api/auth/email/resend-verification/route.ts
@@ -1,0 +1,55 @@
+import { addMinutes } from "date-fns";
+import { eq } from "drizzle-orm";
+import { nanoid } from "nanoid";
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import { db } from "@/db";
+import { usersTable, verificationsTable } from "@/db/schema";
+import { sendVerificationEmail } from "@/lib/email/send-verification-email";
+
+const schema = z.object({
+  email: z.string().trim().email({ message: "Invalid email address" }),
+});
+
+export async function POST(request: Request) {
+  const body = await request.json();
+  const result = schema.safeParse(body);
+
+  if (!result.success) {
+    return new Response(result.error.message, { status: 400 });
+  }
+
+  const email = result.data.email;
+
+  const user = await db.query.usersTable.findFirst({
+    where: eq(usersTable.email, email),
+  });
+
+  if (!user) {
+    return new Response("This e-mail does not exist on our system", {
+      status: 400,
+    });
+  }
+
+  const token = nanoid(32);
+  const expiresAt = addMinutes(new Date(), 15);
+
+  await db.delete(verificationsTable).where(eq(verificationsTable.identifier, email));
+
+  await db.insert(verificationsTable).values({
+    identifier: user.email,
+    value: token,
+    expiresAt,
+  });
+
+  await sendVerificationEmail({
+    user: {
+      name: user.name,
+      email: user.email,
+    },
+    token,
+  });
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/verify-email/route.ts
+++ b/src/app/api/verify-email/route.ts
@@ -1,0 +1,33 @@
+import { and, eq, gt } from "drizzle-orm";
+import { NextResponse } from "next/server";
+
+import { db } from "@/db";
+import { usersTable,verificationsTable } from "@/db/schema";
+
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const token = url.searchParams.get("token");
+
+  if (!token) {
+    return NextResponse.json({ error: "Token inválido" }, { status: 400 });
+  }
+
+  const now = new Date();
+  const [record] = await db
+    .select()
+    .from(verificationsTable)
+    .where(and(eq(verificationsTable.value, token), gt(verificationsTable.expiresAt, now)));
+
+  if (!record) {
+    return NextResponse.json({ error: "Token inválido ou expirado" }, { status: 400 });
+  }
+
+  await db
+    .update(usersTable)
+    .set({ emailVerified: true })
+    .where(eq(usersTable.email, record.identifier));
+
+  await db.delete(verificationsTable).where(eq(verificationsTable.id, record.id));
+
+  return NextResponse.redirect("/email-verificado");
+}

--- a/src/app/auth/sign-in/_components/sign-in-form.tsx
+++ b/src/app/auth/sign-in/_components/sign-in-form.tsx
@@ -43,6 +43,7 @@ export function SignInForm() {
   const router = useRouter();
   const [step, setStep] = useState<"email" | "password">("email");
   const [email, setEmail] = useState("");
+  const [rememberMe, setRememberMe] = useState(false);
 
   const emailForm = useForm<z.infer<typeof emailSchema>>({
     resolver: zodResolver(emailSchema),
@@ -89,6 +90,7 @@ export function SignInForm() {
       const response = await signIn({
         email: values.email,
         password: values.password,
+        rememberMe,
       });
       if (!response?.data?.user) {
         throw new Error("Authentication failed");
@@ -228,6 +230,18 @@ export function SignInForm() {
                   </FormItem>
                 )}
               />
+              <div className="flex items-center space-x-2">
+                <input
+                  id="rememberMe"
+                  type="checkbox"
+                  checked={rememberMe}
+                  onChange={(e) => setRememberMe(e.target.checked)}
+                  className="rounded border-gray-300"
+                />
+                <label htmlFor="rememberMe" className="text-sm">
+                  Remember me
+                </label>
+              </div>
               <div className="flex w-full justify-end">
                 <button
                   type="button"

--- a/src/app/auth/sign-up/_components/sign-up-form.tsx
+++ b/src/app/auth/sign-up/_components/sign-up-form.tsx
@@ -25,6 +25,7 @@ import { authClient } from "@/lib/auth-client";
 import { signUp } from "@/services/auth";
 
 import { SocialLoginButton } from "../../_components/social-login-button";
+import { sendVerificationEmail as requestVerification } from "../verify-email/_helpers/send-verification-email";
 
 const registerSchema = z.object({
   name: z.string().trim().min(1, { message: "Name is required" }),
@@ -99,8 +100,14 @@ export function SignUpForm() {
       }
       return response;
     },
-    onSuccess: () => {
-      router.push("/dashboard");
+    onSuccess: async (_data, variables) => {
+      const email = variables.email;
+      try {
+        await requestVerification(email);
+      } catch {
+        // ignore error and continue
+      }
+      router.push(`/auth/verify-email?email=${encodeURIComponent(email)}`);
     },
     onError: (error: Error) => {
       toast.error(error.message);

--- a/src/app/auth/verify-email/_helpers/send-verification-email.ts
+++ b/src/app/auth/verify-email/_helpers/send-verification-email.ts
@@ -1,0 +1,14 @@
+export async function sendVerificationEmail(email: string) {
+  const res = await fetch("/api/auth/email/resend-verification", {
+    method: "POST",
+    body: JSON.stringify({ email }),
+    headers: { "Content-Type": "application/json" },
+  });
+
+  if (!res.ok) {
+    const data = await res.json();
+    throw new Error(data.message || "Failed to send email.");
+  }
+
+  return true;
+}

--- a/src/app/auth/verify-email/page.tsx
+++ b/src/app/auth/verify-email/page.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useMutation } from "@tanstack/react-query";
+import { useRouter,useSearchParams } from "next/navigation";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+import { sendVerificationEmail } from "./_helpers/send-verification-email";
+
+export default function VerifyEmailPage() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const email = searchParams.get("email");
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      if (!email) throw new Error();
+      await sendVerificationEmail(email);
+    },
+    onSuccess: () => {
+      toast.success("Verification email sent");
+    },
+    onError: () => {
+      toast.error("Failed to resend email.");
+    },
+  });
+
+  return (
+    <div className="flex w-screen items-center justify-center">
+      <div className="w-[400px]">
+        <Card className="h-auto w-full border-0 shadow-2xl">
+          <CardHeader className="space-y-2">
+            <CardTitle className="text-2xl font-semibold">Check your email</CardTitle>
+            <CardDescription>
+              We sent a verification link to <strong>{email}</strong>. If you haven&apos;t received it,
+              click the button below to resend.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <Button
+              type="button"
+              className="h-12 w-full bg-blue-600 hover:bg-blue-700"
+              onClick={() => mutation.mutate()}
+              disabled={mutation.isPending}
+            >
+              Resend email
+            </Button>
+            <Button
+              type="button"
+              className="h-12 w-full"
+              variant="ghost"
+              onClick={() => router.push("/auth/sign-in")}
+            >
+              Go back to login
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/src/app/email-verificado/page.tsx
+++ b/src/app/email-verificado/page.tsx
@@ -1,0 +1,14 @@
+import Link from "next/link";
+
+export default function EmailVerificadoPage() {
+  return (
+    <div className="flex h-screen items-center justify-center">
+      <div className="space-y-4 text-center">
+        <h1 className="text-2xl font-semibold">E-mail verificado com sucesso!</h1>
+        <Link href="/auth/sign-in" className="text-blue-600 underline">
+          Fazer login
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -15,13 +15,14 @@ export function signUp(
 }
 
 export function signIn(
-  values: { email: string; password: string },
+  values: { email: string; password: string; rememberMe?: boolean },
   options?: Parameters<typeof authClient.signIn.email>[1],
 ) {
   return authClient.signIn.email(
     {
       email: values.email,
       password: values.password,
+      rememberMe: values.rememberMe,
     },
     options,
   );


### PR DESCRIPTION
## Summary
- implement verification token routes
- allow resending verification email via API
- add client helper and pages for email verification feedback
- request email verification after sign up
- add remember me checkbox and flag on sign in
- support rememberMe in auth service

## Testing
- `npm run lint` *(fails: React Hook useAction called conditionally)*

------
https://chatgpt.com/codex/tasks/task_e_684b8a7c07648330bf45196c7c071614