### PR TITLE
Add editable general settings

### DIFF
--- a/src/actions/update-clinic/index.tsx
+++ b/src/actions/update-clinic/index.tsx
@@ -1,0 +1,21 @@
+"use server";
+
+import { eq } from "drizzle-orm";
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+
+import { db } from "@/db";
+import { clinicsTable } from "@/db/schema";
+import { protectedWithClinicActionClient } from "@/lib/next-safe-action";
+
+export const updateClinic = protectedWithClinicActionClient
+  .schema(z.object({ name: z.string().min(1, { message: "Clinic name is required" }) }))
+  .action(async ({ parsedInput, ctx }) => {
+    await db
+      .update(clinicsTable)
+      .set({ name: parsedInput.name, updatedAt: new Date() })
+      .where(eq(clinicsTable.id, ctx.clinic.id));
+
+    revalidatePath("/settings/general");
+    return { success: true };
+  });

--- a/src/actions/update-password/index.tsx
+++ b/src/actions/update-password/index.tsx
@@ -1,0 +1,56 @@
+"use server";
+
+import { hashPassword, verifyPassword } from "better-auth/crypto";
+import { and, eq } from "drizzle-orm";
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+
+import { db } from "@/db";
+import { accountsTable } from "@/db/schema";
+import { protectedActionClient } from "@/lib/next-safe-action";
+
+export const updatePassword = protectedActionClient
+  .schema(
+    z.object({
+      currentPassword: z.string(),
+      newPassword: z.string().min(6, { message: "Password must have at least 6 characters" }),
+    }),
+  )
+  .action(async ({ parsedInput, ctx }) => {
+    const account = await db.query.accountsTable.findFirst({
+      where: and(
+        eq(accountsTable.userId, ctx.user.id),
+        eq(accountsTable.providerId, "credential"),
+      ),
+    });
+
+    if (account?.password) {
+      const isValid = await verifyPassword({ hash: account.password, password: parsedInput.currentPassword });
+      if (!isValid) throw new Error("Invalid current password");
+      const hashed = await hashPassword(parsedInput.newPassword);
+      await db
+        .update(accountsTable)
+        .set({ password: hashed, updatedAt: new Date() })
+        .where(eq(accountsTable.id, account.id));
+    } else {
+      const hashed = await hashPassword(parsedInput.newPassword);
+      if (account) {
+        await db
+          .update(accountsTable)
+          .set({ password: hashed, updatedAt: new Date() })
+          .where(eq(accountsTable.id, account.id));
+      } else {
+        await db.insert(accountsTable).values({
+          userId: ctx.user.id,
+          providerId: "credential",
+          accountId: ctx.user.id,
+          password: hashed,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        });
+      }
+    }
+
+    revalidatePath("/settings/general");
+    return { success: true };
+  });

--- a/src/actions/update-preferences/index.tsx
+++ b/src/actions/update-preferences/index.tsx
@@ -1,0 +1,38 @@
+"use server";
+
+import { eq } from "drizzle-orm";
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+
+import { db } from "@/db";
+import { usersTable } from "@/db/schema";
+import { protectedActionClient } from "@/lib/next-safe-action";
+
+export const updatePreferences = protectedActionClient
+  .schema(
+    z.object({
+      theme: z.enum(["light", "dark", "system"]).optional(),
+      language: z.string().optional(),
+    }),
+  )
+  .action(async ({ parsedInput, ctx }) => {
+    const user = await db.query.usersTable.findFirst({
+      where: eq(usersTable.id, ctx.user.id),
+    });
+
+    const prefs = user?.preferences ?? {};
+    await db
+      .update(usersTable)
+      .set({
+        preferences: {
+          ...prefs,
+          theme: parsedInput.theme ?? prefs.theme ?? null,
+          language: parsedInput.language ?? prefs.language ?? null,
+        },
+        updatedAt: new Date(),
+      })
+      .where(eq(usersTable.id, ctx.user.id));
+
+    revalidatePath("/settings/general");
+    return { success: true };
+  });

--- a/src/app/(protected)/settings/general/_components/clinic-name-form.tsx
+++ b/src/app/(protected)/settings/general/_components/clinic-name-form.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Loader2 } from "lucide-react";
+import { useAction } from "next-safe-action/hooks";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+import { z } from "zod";
+
+import { updateClinic } from "@/actions/update-clinic";
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+
+const formSchema = z.object({
+  name: z.string().trim().min(1, { message: "Clinic name is required" }),
+});
+
+export default function ClinicNameForm({ defaultName }: { defaultName: string }) {
+  const form = useForm<z.infer<typeof formSchema>>({
+    resolver: zodResolver(formSchema),
+    defaultValues: { name: defaultName },
+  });
+
+  const action = useAction(updateClinic, {
+    onSuccess: () => toast.success("Clinic updated"),
+    onError: () => toast.error("Failed to update clinic"),
+  });
+
+  const onSubmit = (values: z.infer<typeof formSchema>) => {
+    action.execute(values);
+  };
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+        <FormField
+          control={form.control}
+          name="name"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Clinic name</FormLabel>
+              <FormControl>
+                <Input {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <Button type="submit" disabled={action.isPending}>
+          {action.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}Save
+          changes
+        </Button>
+      </form>
+    </Form>
+  );
+}

--- a/src/app/(protected)/settings/general/_components/password-form.tsx
+++ b/src/app/(protected)/settings/general/_components/password-form.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Loader2 } from "lucide-react";
+import { useAction } from "next-safe-action/hooks";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+import { z } from "zod";
+
+import { updatePassword } from "@/actions/update-password";
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+
+const formSchema = z.object({
+  currentPassword: z.string().min(1, { message: "Required" }),
+  newPassword: z.string().min(6, { message: "Min 6 characters" }),
+});
+
+export default function PasswordForm() {
+  const form = useForm<z.infer<typeof formSchema>>({
+    resolver: zodResolver(formSchema),
+    defaultValues: { currentPassword: "", newPassword: "" },
+  });
+
+  const action = useAction(updatePassword, {
+    onSuccess: () => {
+      toast.success("Password updated");
+      form.reset();
+    },
+    onError: (err) => toast.error(err.message || "Error"),
+  });
+
+  const onSubmit = (values: z.infer<typeof formSchema>) => {
+    action.execute(values);
+  };
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+        <FormField
+          control={form.control}
+          name="currentPassword"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Current password</FormLabel>
+              <FormControl>
+                <Input type="password" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="newPassword"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>New password</FormLabel>
+              <FormControl>
+                <Input type="password" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <Button type="submit" disabled={action.isPending}>
+          {action.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}Save
+          changes
+        </Button>
+      </form>
+    </Form>
+  );
+}

--- a/src/app/(protected)/settings/general/_components/preferences-form.tsx
+++ b/src/app/(protected)/settings/general/_components/preferences-form.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Loader2 } from "lucide-react";
+import { useAction } from "next-safe-action/hooks";
+import { useTheme } from "next-themes";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+import { z } from "zod";
+
+import { updatePreferences } from "@/actions/update-preferences";
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+
+const formSchema = z.object({
+  language: z.string().optional(),
+  theme: z.enum(["light", "dark", "system"]),
+});
+
+interface PreferencesFormProps {
+  defaultLanguage?: string | null;
+  defaultTheme: "light" | "dark" | "system" | null;
+}
+
+export default function PreferencesForm({ defaultLanguage, defaultTheme }: PreferencesFormProps) {
+  const form = useForm<z.infer<typeof formSchema>>({
+    resolver: zodResolver(formSchema),
+    defaultValues: { language: defaultLanguage ?? "en", theme: defaultTheme ?? "system" },
+  });
+
+  const { setTheme } = useTheme();
+
+  const action = useAction(updatePreferences, {
+    onSuccess: () => toast.success("Preferences updated"),
+    onError: () => toast.error("Failed to update preferences"),
+  });
+
+  const onSubmit = (values: z.infer<typeof formSchema>) => {
+    action.execute(values);
+    setTheme(values.theme);
+  };
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+        <FormField
+          control={form.control}
+          name="language"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Language</FormLabel>
+              <FormControl>
+                <Select onValueChange={field.onChange} defaultValue={field.value}>
+                  <SelectTrigger className="w-[200px]">
+                    <SelectValue placeholder="Select" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="en">English</SelectItem>
+                    <SelectItem value="pt">Portuguese</SelectItem>
+                  </SelectContent>
+                </Select>
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="theme"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Theme</FormLabel>
+              <FormControl>
+                <Select onValueChange={field.onChange} defaultValue={field.value}>
+                  <SelectTrigger className="w-[200px]">
+                    <SelectValue placeholder="Select" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="light">Light</SelectItem>
+                    <SelectItem value="dark">Dark</SelectItem>
+                    <SelectItem value="system">System</SelectItem>
+                  </SelectContent>
+                </Select>
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <Button type="submit" disabled={action.isPending}>
+          {action.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}Save
+          changes
+        </Button>
+      </form>
+    </Form>
+  );
+}

--- a/src/app/(protected)/settings/general/page.tsx
+++ b/src/app/(protected)/settings/general/page.tsx
@@ -1,155 +1,27 @@
-"use client";
+import { headers } from "next/headers";
 
-import { CopyIcon, UploadIcon } from "lucide-react";
-import * as React from "react";
+import WithAuthentication from "@/hocs/with-authentication";
+import { auth } from "@/lib/auth";
 
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { Separator } from "@/components/ui/separator";
+import ProfileForm from "../_components/profile-form";
+import ClinicNameForm from "./_components/clinic-name-form";
+import PasswordForm from "./_components/password-form";
+import PreferencesForm from "./_components/preferences-form";
 
-export default function GeneralSettingsPage() {
-  const [orgId] = React.useState("org_krc321iuwrht123rylwelBuda");
-  const [displayName, setDisplayName] = React.useState("nivo.video");
-  const [orgSlug, setOrgSlug] = React.useState("nivo-video");
-
-  const copyToClipboard = (text: string) => {
-    navigator.clipboard.writeText(text);
-  };
+export default async function GeneralSettingsPage() {
+  const session = await auth.api.getSession({ headers: await headers() });
 
   return (
-    <div className="space-y-8 pt-12">
-      <div className="space-y-8">
-        <div className="space-y-3">
-          <div>
-            <Label className="text-base font-medium">Organization ID</Label>
-            <p className="text-muted-foreground text-sm">
-              This is your user ID within Nivo API
-            </p>
-          </div>
-          <div className="flex items-center gap-2">
-            <Input
-              value={orgId}
-              readOnly
-              className="bg-muted font-mono text-sm"
-            />
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => copyToClipboard(orgId)}
-            >
-              <CopyIcon className="h-4 w-4" />
-              Copy
-            </Button>
-          </div>
-        </div>
-
-        {/* Display Name */}
-        <div className="space-y-3">
-          <div>
-            <Label className="text-base font-medium">Display name</Label>
-            <p className="text-muted-foreground text-sm">
-              How your organization name is displayed within Nivo.
-            </p>
-          </div>
-          <div className="flex items-center gap-2">
-            <Input
-              value={displayName}
-              onChange={(e) => setDisplayName(e.target.value)}
-              className="max-w-md"
-            />
-            <Button size="sm">Save</Button>
-          </div>
-        </div>
-
-        {/* Organization Slug */}
-        <div className="space-y-3">
-          <div>
-            <Label className="text-base font-medium">Organization Slug</Label>
-            <p className="text-muted-foreground text-sm">
-              The slug displayed on the URL when sharing public links.
-            </p>
-          </div>
-          <div className="flex items-center gap-2">
-            <div className="flex items-center">
-              <span className="text-muted-foreground mr-1 text-sm">
-                nivo.video/
-              </span>
-              <Input
-                value={orgSlug}
-                onChange={(e) => setOrgSlug(e.target.value)}
-                className="max-w-48"
-              />
-            </div>
-          </div>
-        </div>
-
-        {/* Organization Avatar */}
-        <div className="space-y-3">
-          <div>
-            <Label className="text-base font-medium">Organization Avatar</Label>
-            <p className="text-muted-foreground text-sm">
-              Recommended 400x400px, PNG or JPG
-            </p>
-          </div>
-          <div className="flex items-center gap-4">
-            <div className="bg-muted flex h-16 w-16 items-center justify-center rounded-lg">
-              <UploadIcon className="text-muted-foreground h-6 w-6" />
-            </div>
-            <Button variant="outline">
-              <UploadIcon className="mr-2 h-4 w-4" />
-              Select image
-            </Button>
-          </div>
-        </div>
-
-        <Separator />
-
-        {/* Leave Organization */}
-        <div className="space-y-3">
-          <div>
-            <Label className="text-base font-medium">Leave Organization</Label>
-            <p className="text-muted-foreground text-sm">
-              Once you leave, you'll lose access to this organization. The
-              organization data won't be deleted.
-            </p>
-          </div>
-          <Button variant="outline" className="text-muted-foreground">
-            Leave Organization
-          </Button>
-        </div>
-
-        <Separator />
-
-        {/* Danger Zone */}
-        <Card className="border-destructive/50">
-          <CardHeader>
-            <CardTitle className="text-destructive flex items-center gap-2">
-              <Badge variant="destructive" className="text-xs">
-                DANGER ZONE
-              </Badge>
-            </CardTitle>
-            <CardDescription>
-              <strong>Delete Organization</strong>
-              <br />
-              All of the organization data will be{" "}
-              <strong>permanently deleted</strong>. This action is not
-              reversible, so please continue with caution.
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <Button variant="destructive">Delete Organization</Button>
-          </CardContent>
-        </Card>
+    <WithAuthentication mustHaveClinic>
+      <div className="space-y-8 pt-12">
+        <ProfileForm user={{ name: session!.user.name, email: session!.user.email }} />
+        <ClinicNameForm defaultName={session!.user.clinic!.name} />
+        <PasswordForm />
+        <PreferencesForm
+          defaultLanguage={session!.user.preferences?.language}
+          defaultTheme={session!.user.preferences?.theme}
+        />
       </div>
-    </div>
+    </WithAuthentication>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import { NuqsAdapter } from "nuqs/adapters/next/app";
 
 import { Toaster } from "@/components/ui/sonner";
 import { ReactQueryProvider } from "@/providers/react-query";
+import { ThemeProvider } from "@/providers/theme-provider";
 
 const monrope = Manrope({
   variable: "--font-monrope",
@@ -24,13 +25,13 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body
-        className={`${monrope.variable} antialiased`}
-      >
-        <ReactQueryProvider>
-          <NuqsAdapter>{children}</NuqsAdapter>
-        </ReactQueryProvider>
-        <Toaster position="bottom-center" richColors theme="light" />
+      <body className={`${monrope.variable} antialiased`}>
+        <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+          <ReactQueryProvider>
+            <NuqsAdapter>{children}</NuqsAdapter>
+          </ReactQueryProvider>
+          <Toaster position="bottom-center" richColors />
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -1,8 +1,8 @@
 "use client"
 
-import * as React from "react"
 import * as CheckboxPrimitive from "@radix-ui/react-checkbox"
 import { CheckIcon } from "lucide-react"
+import * as React from "react"
 
 import { cn } from "@/lib/utils"
 

--- a/src/providers/theme-provider.tsx
+++ b/src/providers/theme-provider.tsx
@@ -1,0 +1,7 @@
+"use client"
+
+import { ThemeProvider as NextThemesProvider, type ThemeProviderProps } from "next-themes";
+
+export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
+  return <NextThemesProvider attribute="class" defaultTheme="system" enableSystem {...props}>{children}</NextThemesProvider>;
+}


### PR DESCRIPTION
## Summary
- enable theme switching via ThemeProvider
- add server actions for updating password, clinic name and user preferences
- implement forms for editing profile, clinic name, password and preferences
- display the forms on the general settings page

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6850a85d6b7083309d3c809f883d4ca5