### PR TITLE
Align settings pages with PageContainer

### DIFF
--- a/src/app/(protected)/settings/general/page.tsx
+++ b/src/app/(protected)/settings/general/page.tsx
@@ -1,5 +1,6 @@
 import { headers } from "next/headers";
 
+import { PageContainer, PageContent } from "@/components/ui/page-container";
 import WithAuthentication from "@/hocs/with-authentication";
 import { auth } from "@/lib/auth";
 
@@ -13,15 +14,19 @@ export default async function GeneralSettingsPage() {
 
   return (
     <WithAuthentication mustHaveClinic>
-      <div className="space-y-8 pt-12">
-        <ProfileForm user={{ name: session!.user.name, email: session!.user.email }} />
-        <ClinicNameForm defaultName={session!.user.clinic!.name} />
-        <PasswordForm />
-        <PreferencesForm
-          defaultLanguage={session!.user.preferences?.language}
-          defaultTheme={session!.user.preferences?.theme}
-        />
-      </div>
+      <PageContainer>
+        <PageContent>
+          <ProfileForm
+            user={{ name: session!.user.name, email: session!.user.email }}
+          />
+          <ClinicNameForm defaultName={session!.user.clinic!.name} />
+          <PasswordForm />
+          <PreferencesForm
+            defaultLanguage={session!.user.preferences?.language}
+            defaultTheme={session!.user.preferences?.theme}
+          />
+        </PageContent>
+      </PageContainer>
     </WithAuthentication>
   );
 }

--- a/src/app/(protected)/settings/invoices/page.tsx
+++ b/src/app/(protected)/settings/invoices/page.tsx
@@ -3,6 +3,7 @@ import { DownloadIcon } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { PageContainer, PageContent } from "@/components/ui/page-container";
 
 const invoices = [
   {
@@ -30,43 +31,45 @@ const invoices = [
 
 export default function InvoicesSettingsPage() {
   return (
-    <div className="space-y-8 pt-12">
-      <div className="space-y-4">
-        {invoices.map((invoice) => (
-          <div
-            key={invoice.id}
-            className="flex items-center justify-between rounded-lg border p-4"
-          >
-            <div className="flex items-center gap-4">
-              <div className="font-medium">{invoice.date}</div>
-              <Badge
-                variant={invoice.status === "PAID" ? "default" : "secondary"}
-                className={invoice.status === "PAID" ? "bg-green-600" : ""}
-              >
-                {invoice.status}
-              </Badge>
-            </div>
-
-            <div className="flex items-center gap-4">
-              <div className="flex items-center gap-2">
-                <div className="flex h-4 w-6 items-center justify-center rounded-sm bg-red-500">
-                  <div className="h-3 w-4 rounded-sm bg-red-600"></div>
-                </div>
-                <span className="text-muted-foreground text-sm">
-                  {invoice.paymentMethod}
-                </span>
+    <PageContainer>
+      <PageContent>
+        <div className="space-y-4">
+          {invoices.map((invoice) => (
+            <div
+              key={invoice.id}
+              className="flex items-center justify-between rounded-lg border p-4"
+            >
+              <div className="flex items-center gap-4">
+                <div className="font-medium">{invoice.date}</div>
+                <Badge
+                  variant={invoice.status === "PAID" ? "default" : "secondary"}
+                  className={invoice.status === "PAID" ? "bg-green-600" : ""}
+                >
+                  {invoice.status}
+                </Badge>
               </div>
 
-              <div className="font-semibold">{invoice.amount}</div>
+              <div className="flex items-center gap-4">
+                <div className="flex items-center gap-2">
+                  <div className="flex h-4 w-6 items-center justify-center rounded-sm bg-red-500">
+                    <div className="h-3 w-4 rounded-sm bg-red-600"></div>
+                  </div>
+                  <span className="text-muted-foreground text-sm">
+                    {invoice.paymentMethod}
+                  </span>
+                </div>
 
-              <Button variant="outline" size="sm">
-                <DownloadIcon className="mr-2 h-4 w-4" />
-                Download
-              </Button>
+                <div className="font-semibold">{invoice.amount}</div>
+
+                <Button variant="outline" size="sm">
+                  <DownloadIcon className="mr-2 h-4 w-4" />
+                  Download
+                </Button>
+              </div>
             </div>
-          </div>
-        ))}
-      </div>
-    </div>
+          ))}
+        </div>
+      </PageContent>
+    </PageContainer>
   );
 }

--- a/src/app/(protected)/settings/members/page.tsx
+++ b/src/app/(protected)/settings/members/page.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { PageContainer, PageContent } from "@/components/ui/page-container";
 import { Separator } from "@/components/ui/separator";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
@@ -56,131 +57,136 @@ export default function MembersSettingsPage() {
   };
 
   return (
-    <div className="space-y-8 pt-12">
-
-      {/* Invite Member */}
-      <div className="space-y-4">
-        <div>
-          <Label className="text-base font-medium">Invite member</Label>
-          <p className="text-muted-foreground text-sm">
-            Invite new members by email address
-          </p>
-        </div>
-        <div className="flex items-center gap-4">
-          <div className="max-w-md flex-1">
-            <Label htmlFor="email" className="sr-only">
-              Email
-            </Label>
-            <Input
-              id="email"
-              type="email"
-              placeholder="Email"
-              value={inviteEmail}
-              onChange={(e) => setInviteEmail(e.target.value)}
-            />
+    <PageContainer>
+      <PageContent>
+        {/* Invite Member */}
+        <div className="space-y-4">
+          <div>
+            <Label className="text-base font-medium">Invite member</Label>
+            <p className="text-muted-foreground text-sm">
+              Invite new members by email address
+            </p>
           </div>
-          <div className="min-w-24">
-            <Label className="sr-only">Role</Label>
-            <Badge variant="secondary">Member</Badge>
-          </div>
-          <Button>Send Invite</Button>
-        </div>
-        <Button variant="link" className="h-auto p-0 text-sm">
-          <LinkIcon className="mr-1 h-4 w-4" />
-          Invite Link
-        </Button>
-      </div>
-
-      <Separator />
-
-      {/* Members List */}
-      <div className="space-y-4">
-        <Tabs defaultValue="members" className="w-full">
-          <TabsList className="grid w-full max-w-md grid-cols-2">
-            <TabsTrigger value="members">Organization Members (12)</TabsTrigger>
-            <TabsTrigger value="pending">Pending Invites (3)</TabsTrigger>
-          </TabsList>
-
-          <TabsContent value="members" className="space-y-4">
-            {/* Search and Actions */}
-            <div className="flex items-center justify-between">
-              <div className="relative max-w-sm">
-                <SearchIcon className="text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 transform" />
-                <Input placeholder="Search for members" className="pl-10" />
-              </div>
-              <div className="flex items-center gap-2">
-                <Button variant="outline" size="sm">
-                  All roles
-                </Button>
-              </div>
-            </div>
-
-            {/* Select All */}
-            <div className="flex items-center gap-2">
-              <Checkbox
-                checked={selectedMembers.length === members.length}
-                onCheckedChange={handleSelectAll}
+          <div className="flex items-center gap-4">
+            <div className="max-w-md flex-1">
+              <Label htmlFor="email" className="sr-only">
+                Email
+              </Label>
+              <Input
+                id="email"
+                type="email"
+                placeholder="Email"
+                value={inviteEmail}
+                onChange={(e) => setInviteEmail(e.target.value)}
               />
-              <Label className="text-sm">Select all ({members.length})</Label>
             </div>
+            <div className="min-w-24">
+              <Label className="sr-only">Role</Label>
+              <Badge variant="secondary">Member</Badge>
+            </div>
+            <Button>Send Invite</Button>
+          </div>
+          <Button variant="link" className="h-auto p-0 text-sm">
+            <LinkIcon className="mr-1 h-4 w-4" />
+            Invite Link
+          </Button>
+        </div>
 
-            {/* Members */}
-            <div className="space-y-3">
-              {members.map((member) => (
-                <div
-                  key={member.id}
-                  className="flex items-center gap-4 rounded-lg border p-3"
-                >
-                  <Checkbox
-                    checked={selectedMembers.includes(member.id)}
-                    onCheckedChange={() => handleSelectMember(member.id)}
-                  />
-                  <Avatar className="h-10 w-10">
-                    <AvatarImage
-                      src={member.avatar || "/placeholder.svg"}
-                      alt={member.name}
-                    />
-                    <AvatarFallback>
-                      {member.name
-                        .split(" ")
-                        .map((n) => n[0])
-                        .join("")}
-                    </AvatarFallback>
-                  </Avatar>
-                  <div className="flex-1">
-                    <div className="font-medium">{member.name}</div>
-                    <div className="text-muted-foreground text-sm">
-                      {member.email}
-                    </div>
-                  </div>
-                  <Badge
-                    variant={member.role === "Owner" ? "default" : "secondary"}
-                  >
-                    {member.role}
-                  </Badge>
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <Button variant="ghost" size="sm">
-                        <MoreHorizontalIcon className="h-4 w-4" />
-                      </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end">
-                      <DropdownMenuItem>Edit role</DropdownMenuItem>
-                      <DropdownMenuItem>Remove member</DropdownMenuItem>
-                    </DropdownMenuContent>
-                  </DropdownMenu>
+        <Separator />
+
+        {/* Members List */}
+        <div className="space-y-4">
+          <Tabs defaultValue="members" className="w-full">
+            <TabsList className="grid w-full max-w-md grid-cols-2">
+              <TabsTrigger value="members">
+                Organization Members (12)
+              </TabsTrigger>
+              <TabsTrigger value="pending">Pending Invites (3)</TabsTrigger>
+            </TabsList>
+
+            <TabsContent value="members" className="space-y-4">
+              {/* Search and Actions */}
+              <div className="flex items-center justify-between">
+                <div className="relative max-w-sm">
+                  <SearchIcon className="text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 transform" />
+                  <Input placeholder="Search for members" className="pl-10" />
                 </div>
-              ))}
-            </div>
-          </TabsContent>
+                <div className="flex items-center gap-2">
+                  <Button variant="outline" size="sm">
+                    All roles
+                  </Button>
+                </div>
+              </div>
 
-          <TabsContent value="pending">
-            <div className="text-muted-foreground py-8 text-center">
-              No pending invites
-            </div>
-          </TabsContent>
-        </Tabs>
-      </div>
-    </div>
+              {/* Select All */}
+              <div className="flex items-center gap-2">
+                <Checkbox
+                  checked={selectedMembers.length === members.length}
+                  onCheckedChange={handleSelectAll}
+                />
+                <Label className="text-sm">Select all ({members.length})</Label>
+              </div>
+
+              {/* Members */}
+              <div className="space-y-3">
+                {members.map((member) => (
+                  <div
+                    key={member.id}
+                    className="flex items-center gap-4 rounded-lg border p-3"
+                  >
+                    <Checkbox
+                      checked={selectedMembers.includes(member.id)}
+                      onCheckedChange={() => handleSelectMember(member.id)}
+                    />
+                    <Avatar className="h-10 w-10">
+                      <AvatarImage
+                        src={member.avatar || "/placeholder.svg"}
+                        alt={member.name}
+                      />
+                      <AvatarFallback>
+                        {member.name
+                          .split(" ")
+                          .map((n) => n[0])
+                          .join("")}
+                      </AvatarFallback>
+                    </Avatar>
+                    <div className="flex-1">
+                      <div className="font-medium">{member.name}</div>
+                      <div className="text-muted-foreground text-sm">
+                        {member.email}
+                      </div>
+                    </div>
+                    <Badge
+                      variant={
+                        member.role === "Owner" ? "default" : "secondary"
+                      }
+                    >
+                      {member.role}
+                    </Badge>
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button variant="ghost" size="sm">
+                          <MoreHorizontalIcon className="h-4 w-4" />
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end">
+                        <DropdownMenuItem>Edit role</DropdownMenuItem>
+                        <DropdownMenuItem>Remove member</DropdownMenuItem>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  </div>
+                ))}
+              </div>
+            </TabsContent>
+
+            <TabsContent value="pending">
+              <div className="text-muted-foreground py-8 text-center">
+                No pending invites
+              </div>
+            </TabsContent>
+          </Tabs>
+        </div>
+      </PageContent>
+    </PageContainer>
   );
 }


### PR DESCRIPTION
## Summary
- use `PageContainer` + `PageContent` in Settings subpages
- keep pages headerless for layout consistency

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6850b2e7761083308cb9f97c70335c97