### PR TITLE
Implement auto-save with debounce

### DIFF
--- a/src/hooks/use-auto-save-setting.ts
+++ b/src/hooks/use-auto-save-setting.ts
@@ -1,0 +1,29 @@
+import { useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
+
+import { useDebounce } from "./use-debounce";
+
+export function useAutoSaveSetting<T>(
+  value: T,
+  patch: (v: T) => Promise<void>,
+  delay = 800,
+) {
+  const debounced = useDebounce(value, delay);
+  const last = useRef<string>(JSON.stringify(value));
+  const [state, setState] = useState<"idle" | "saving" | "error">("idle");
+
+  useEffect(() => {
+    const serialized = JSON.stringify(debounced);
+    if (serialized === last.current) return;
+    last.current = serialized;
+    setState("saving");
+    patch(debounced)
+      .then(() => setState("idle"))
+      .catch(() => {
+        setState("error");
+        toast.error("Erro ao salvar");
+      });
+  }, [debounced, patch]);
+
+  return state;
+}

--- a/src/hooks/use-debounce.ts
+++ b/src/hooks/use-debounce.ts
@@ -1,0 +1,12 @@
+import { useEffect, useState } from "react";
+
+export function useDebounce<T>(value: T, delay = 500) {
+  const [debounced, setDebounced] = useState(value);
+
+  useEffect(() => {
+    const id = setTimeout(() => setDebounced(value), delay);
+    return () => clearTimeout(id);
+  }, [value, delay]);
+
+  return debounced;
+}

--- a/src/v0-vercel/page.tsx
+++ b/src/v0-vercel/page.tsx
@@ -118,8 +118,8 @@ export default function GeneralSettingsPage() {
           <div>
             <Label className="text-base font-medium">Leave Organization</Label>
             <p className="text-muted-foreground text-sm">
-              Once you leave, you'll lose access to this organization. The
-              organization data won't be deleted.
+              Once you leave, you&apos;ll lose access to this organization. The
+              organization data won&apos;t be deleted.
             </p>
           </div>
           <Button variant="outline" className="text-muted-foreground">


### PR DESCRIPTION
## Summary
- add generic `useDebounce` and `useAutoSaveSetting` hooks
- switch profile and clinic name forms to auto-save on typing
- auto-save preferences form and apply theme automatically
- fix lint issue in v0-vercel example page

## Testing
- `npx prettier --write src/hooks/use-debounce.ts src/hooks/use-auto-save-setting.ts src/app/(protected)/settings/general/_components/clinic-name-form.tsx src/app/(protected)/settings/_components/profile-form.tsx src/app/(protected)/settings/general/_components/preferences-form.tsx`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6850ba7945e0833088bf700c34ecec29