### PR TITLE
Add language toggle with basic i18n

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { Manrope } from "next/font/google";
 import { NuqsAdapter } from "nuqs/adapters/next/app";
 
 import { Toaster } from "@/components/ui/sonner";
+import { LocaleProvider } from "@/providers/locale-provider";
 import { ReactQueryProvider } from "@/providers/react-query";
 import { ThemeProvider } from "@/providers/theme-provider";
 
@@ -26,12 +27,14 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={`${monrope.variable} antialiased`}>
-        <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
-          <ReactQueryProvider>
-            <NuqsAdapter>{children}</NuqsAdapter>
-          </ReactQueryProvider>
-          <Toaster position="bottom-center" richColors />
-        </ThemeProvider>
+        <LocaleProvider>
+          <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+            <ReactQueryProvider>
+              <NuqsAdapter>{children}</NuqsAdapter>
+            </ReactQueryProvider>
+            <Toaster position="bottom-center" richColors />
+          </ThemeProvider>
+        </LocaleProvider>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -16,6 +16,7 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 
+import { LanguageSwitcher } from "@/components/language-switcher";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -26,8 +27,10 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
+import { useLocale } from "@/providers/locale-provider";
 
 export default function Home() {
+  const { t } = useLocale();
   return (
     <div className="bg-background min-h-screen">
       {/* Header */}
@@ -42,28 +45,27 @@ export default function Home() {
               href="#features"
               className="text-muted-foreground hover:text-foreground"
             >
-              Recursos
+              {t("nav.features")}
             </Link>
             <Link
               href="#pricing"
               className="text-muted-foreground hover:text-foreground"
             >
-              Preços
+              {t("nav.pricing")}
             </Link>
             <Link
               href="#contact"
               className="text-muted-foreground hover:text-foreground"
             >
-              Contato
+              {t("nav.contact")}
             </Link>
-            <Button variant="outline">
-              Entrar
-            </Button>
-            <Button>Começar Grátis</Button>
+            <Button variant="outline">{t("nav.signIn")}</Button>
+            <Button>{t("nav.startFree")}</Button>
           </nav>
           <Button variant="ghost" size="icon" className="md:hidden">
             <Menu className="h-6 w-6" />
           </Button>
+          <LanguageSwitcher />
         </div>
       </header>
 
@@ -71,38 +73,35 @@ export default function Home() {
       <section className="px-4 py-20">
         <div className="container mx-auto max-w-4xl text-center">
           <Badge variant="secondary" className="mb-4">
-            ✨ Novo: Integração com WhatsApp disponível
+            {t("hero.newIntegration")}
           </Badge>
           <h1 className="from-primary to-primary/60 mb-6 bg-gradient-to-r bg-clip-text text-4xl font-bold text-transparent md:text-6xl">
-            Simplifique seus agendamentos com inteligência
+            {t("hero.heading")}
           </h1>
           <p className="text-muted-foreground mx-auto mb-8 max-w-2xl text-xl">
-            Gerencie compromissos, clientes e pagamentos em uma única
-            plataforma. Automatize seu negócio e foque no que realmente importa.
+            {t("hero.description")}
           </p>
           <div className="mb-12 flex flex-col justify-center gap-4 sm:flex-row">
             <Button size="lg" className="px-8 text-lg">
-              Começar Gratuitamente
+              {t("hero.startFree")}
               <ArrowRight className="ml-2 h-5 w-5" />
             </Button>
             <Button size="lg" variant="outline" className="px-8 text-lg">
-              Ver Demonstração
+              {t("hero.demo")}
             </Button>
           </div>
           <div className="mt-16 grid grid-cols-1 gap-8 md:grid-cols-3">
             <div className="text-center">
               <div className="text-primary mb-2 text-3xl font-bold">50k+</div>
-              <div className="text-muted-foreground">
-                Agendamentos realizados
-              </div>
+              <div className="text-muted-foreground">{t("hero.metrics1")}</div>
             </div>
             <div className="text-center">
               <div className="text-primary mb-2 text-3xl font-bold">2k+</div>
-              <div className="text-muted-foreground">Empresas ativas</div>
+              <div className="text-muted-foreground">{t("hero.metrics2")}</div>
             </div>
             <div className="text-center">
               <div className="text-primary mb-2 text-3xl font-bold">99.9%</div>
-              <div className="text-muted-foreground">Uptime garantido</div>
+              <div className="text-muted-foreground">{t("hero.metrics3")}</div>
             </div>
           </div>
         </div>

--- a/src/components/language-switcher.tsx
+++ b/src/components/language-switcher.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { Locale,useLocale } from "@/providers/locale-provider";
+
+export function LanguageSwitcher() {
+  const { locale, setLocale } = useLocale();
+  const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setLocale(e.target.value as Locale);
+  };
+  return (
+    <select
+      onChange={handleChange}
+      value={locale}
+      className="border rounded p-1 text-sm bg-background"
+    >
+      <option value="en">EN</option>
+      <option value="pt">PT</option>
+    </select>
+  );
+}

--- a/src/providers/locale-provider.tsx
+++ b/src/providers/locale-provider.tsx
@@ -1,0 +1,111 @@
+import { createContext, ReactNode,useContext, useState } from "react";
+
+export type Locale = "en" | "pt";
+
+interface LocaleContextValue {
+  locale: Locale;
+  setLocale: (locale: Locale) => void;
+  t: (key: string) => string;
+}
+
+type TranslationDictionary = {
+  nav: {
+    features: string;
+    pricing: string;
+    contact: string;
+    signIn: string;
+    startFree: string;
+  };
+  hero: {
+    newIntegration: string;
+    heading: string;
+    description: string;
+    startFree: string;
+    demo: string;
+    metrics1: string;
+    metrics2: string;
+    metrics3: string;
+  };
+};
+
+const translations: Record<Locale, TranslationDictionary> = {
+  en: {
+    nav: {
+      features: "Features",
+      pricing: "Pricing",
+      contact: "Contact",
+      signIn: "Sign In",
+      startFree: "Get Started",
+    },
+    hero: {
+      newIntegration: "\u2728 New: WhatsApp integration available",
+      heading: "Simplify your scheduling with intelligence",
+      description:
+        "Manage appointments, clients and payments in a single platform. Automate your business and focus on what really matters.",
+      startFree: "Start Free",
+      demo: "View Demo",
+      metrics1: "Appointments made",
+      metrics2: "Active companies",
+      metrics3: "Guaranteed uptime",
+    },
+  },
+  pt: {
+    nav: {
+      features: "Recursos",
+      pricing: "Pre\u00e7os",
+      contact: "Contato",
+      signIn: "Entrar",
+      startFree: "Come\u00e7ar Gr\u00e1tis",
+    },
+    hero: {
+      newIntegration: "\u2728 Novo: Integra\u00e7\u00e3o com WhatsApp dispon\u00edvel",
+      heading: "Simplifique seus agendamentos com intelig\u00eancia",
+      description:
+        "Gerencie compromissos, clientes e pagamentos em uma \u00fanica plataforma. Automatize seu neg\u00f3cio e foque no que realmente importa.",
+      startFree: "Come\u00e7ar Gratuitamente",
+      demo: "Ver Demonstra\u00e7\u00e3o",
+      metrics1: "Agendamentos realizados",
+      metrics2: "Empresas ativas",
+      metrics3: "Uptime garantido",
+    },
+  },
+};
+
+const LocaleContext = createContext<LocaleContextValue | undefined>(undefined);
+
+export function LocaleProvider({
+  children,
+  defaultLocale = "en",
+}: {
+  children: ReactNode;
+  defaultLocale?: Locale;
+}) {
+  const [locale, setLocale] = useState<Locale>(defaultLocale);
+
+  const t = (key: string) => {
+    const parts = key.split(".");
+    let value: unknown = translations[locale] as Record<string, unknown>;
+    for (const part of parts) {
+      if (typeof value === "object" && value && part in value) {
+        value = (value as Record<string, unknown>)[part];
+      } else {
+        return key;
+      }
+    }
+    return typeof value === "string" ? value : key;
+  };
+
+  return (
+    <LocaleContext.Provider value={{ locale, setLocale, t }}>
+      {children}
+    </LocaleContext.Provider>
+  );
+}
+
+export function useLocale() {
+  const context = useContext(LocaleContext);
+  if (!context) {
+    throw new Error("useLocale must be used within a LocaleProvider");
+  }
+  return context;
+}


### PR DESCRIPTION
## Summary
- add simple i18n provider with English and Portuguese strings
- expose language switcher component
- wrap app with `LocaleProvider`
- internationalize landing page navigation and hero section

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6850be60c6488330a5b91e504f3504ef