### PR TITLE
Implement session management for admin

### DIFF
--- a/src/app/(protected)/settings/layout.tsx
+++ b/src/app/(protected)/settings/layout.tsx
@@ -1,35 +1,25 @@
 "use client";
 
-import { CreditCardIcon, Gem, SettingsIcon, UsersIcon } from "lucide-react";
+import {
+  CreditCardIcon,
+  Gem,
+  KeyRound,
+  SettingsIcon,
+  UsersIcon,
+} from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import type * as React from "react";
 
 import { Button } from "@/components/ui/button";
+import { authClient } from "@/lib/auth-client";
 import { cn } from "@/lib/utils";
 
-const settingsNavItems = [
-  {
-    title: "General",
-    href: "/settings/general",
-    icon: SettingsIcon,
-  },
-  {
-    title: "Subscription",
-    href: "/settings/subscription",
-    icon: Gem,
-  },
-  {
-    title: "Invoices",
-    href: "/settings/invoices",
-    icon: CreditCardIcon,
-  },
-  {
-    title: "Members",
-    href: "/settings/members",
-    icon: UsersIcon,
-  },
-];
+interface NavItem {
+  title: string;
+  href: string;
+  icon: React.ComponentType<{ className?: string }>;
+}
 
 export default function SettingsLayout({
   children,
@@ -37,6 +27,41 @@ export default function SettingsLayout({
   children: React.ReactNode;
 }) {
   const pathname = usePathname();
+  const { data: session } = authClient.useSession();
+
+  const isAdmin = session?.user?.clinic?.role === "ADMIN";
+
+  const settingsNavItems: NavItem[] = [
+    {
+      title: "General",
+      href: "/settings/general",
+      icon: SettingsIcon,
+    },
+    {
+      title: "Subscription",
+      href: "/settings/subscription",
+      icon: Gem,
+    },
+    {
+      title: "Invoices",
+      href: "/settings/invoices",
+      icon: CreditCardIcon,
+    },
+    {
+      title: "Members",
+      href: "/settings/members",
+      icon: UsersIcon,
+    },
+    ...(isAdmin
+      ? ([
+          {
+            title: "Sessions",
+            href: "/settings/sessions",
+            icon: KeyRound,
+          },
+        ] as const)
+      : []),
+  ];
 
   return (
     <div className="flex min-h-screen">

--- a/src/app/(protected)/settings/sessions/page.tsx
+++ b/src/app/(protected)/settings/sessions/page.tsx
@@ -1,4 +1,6 @@
 
+import { headers } from "next/headers";
+
 import {
   PageContainer,
   PageContent,
@@ -8,10 +10,12 @@ import {
   PageTitle,
 } from "@/components/ui/page-container";
 import WithAuthentication from "@/hocs/with-authentication";
+import { auth } from "@/lib/auth";
 
 import SessionsTable from "./_components/sessions-table";
 
 const SessionsPage = async () => {
+  const session = await auth.api.getSession({ headers: await headers() });
 
   return (
     <WithAuthentication mustHaveRole="ADMIN">
@@ -23,7 +27,7 @@ const SessionsPage = async () => {
           </PageHeaderContent>
         </PageHeader>
         <PageContent>
-          <SessionsTable />
+          <SessionsTable sessions={session!.sessions ?? []} />
         </PageContent>
       </PageContainer>
     </WithAuthentication>


### PR DESCRIPTION
## Summary
- allow admins to list and revoke sessions
- show Sessions link in settings sidebar when the user is ADMIN
- fetch sessions server‑side and manage them client‑side

## Testing
- `npm run lint` *(fails: Parsing error and unused vars in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_6852208cb770833089717bb0604c720d