### PR TITLE
Enable avatar upload to S3

### DIFF
--- a/src/app/(protected)/settings/general/_components/profile-form.tsx
+++ b/src/app/(protected)/settings/general/_components/profile-form.tsx
@@ -2,15 +2,16 @@
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation } from "@tanstack/react-query";
-import { Loader2, User } from "lucide-react";
+import { CircleUserRoundIcon, Loader2, User, XIcon } from "lucide-react";
 import { useAction } from "next-safe-action/hooks";
+import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod";
 
 import { updateProfile } from "@/actions/update-profile";
 import { sendEmailRequest } from "@/client-actions/send-email";
-import AvatarUpload from "@/components/ui/avatar-upload";
+import { uploadAvatar } from "@/client-actions/upload-avatar";
 import { Button } from "@/components/ui/button";
 import {
   Form,
@@ -23,6 +24,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { useAutoSaveSetting } from "@/hooks/use-auto-save-setting";
 import { useEmailVerified } from "@/hooks/use-email-verified";
+import { useFileUpload } from "@/hooks/use-file-upload";
 
 interface ProfileFormProps {
   user: {
@@ -57,11 +59,107 @@ export default function ClinicForm({ user }: ProfileFormProps) {
     action.executeAsync({ name: v }),
   );
 
+  const [avatarUrl, setAvatarUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch("/api/user/avatar")
+      .then((res) => (res.ok ? res.json() : { url: null }))
+      .then((data) => setAvatarUrl(data.url ?? null))
+      .catch(() => setAvatarUrl(null));
+  }, []);
+
+  const [
+    { files, isDragging },
+    {
+      removeFile,
+      openFileDialog,
+      getInputProps,
+      handleDragEnter,
+      handleDragLeave,
+      handleDragOver,
+      handleDrop,
+      clearFiles,
+    },
+  ] = useFileUpload({ maxSize: 5 * 1024 * 1024, accept: "image/*" });
+
+  const file = files[0]?.file instanceof File ? (files[0].file as File) : null;
+  const previewUrl = files[0]?.preview || avatarUrl || null;
+
+  const uploadAvatarMutation = useMutation({
+    mutationFn: async () => {
+      if (!file) throw new Error("No file selected");
+      return uploadAvatar(file);
+    },
+    onSuccess: (data) => {
+      setAvatarUrl(data.url);
+      clearFiles();
+      toast.success("Avatar updated successfully");
+    },
+    onError: () => toast.error("Upload failed. Try again."),
+  });
+
   return (
     <div className="space-y-6">
       {/* Avatar Upload Section */}
       <div className="flex flex-col items-center space-y-4 sm:flex-row sm:items-start sm:space-y-0 sm:space-x-6">
-        <AvatarUpload />
+        <div className="flex flex-col items-center gap-2">
+          <div className="relative inline-flex">
+            <button
+              className="border-input hover:bg-accent/50 data-[dragging=true]:bg-accent/50 focus-visible:border-ring focus-visible:ring-ring/50 relative flex size-16 items-center justify-center overflow-hidden rounded-full border border-dashed transition-colors outline-none focus-visible:ring-[3px] has-disabled:pointer-events-none has-disabled:opacity-50 has-[img]:border-none"
+              onClick={openFileDialog}
+              onDragEnter={handleDragEnter}
+              onDragLeave={handleDragLeave}
+              onDragOver={handleDragOver}
+              onDrop={handleDrop}
+              data-dragging={isDragging || undefined}
+              aria-label={previewUrl ? "Change image" : "Upload image"}
+            >
+              {previewUrl ? (
+                <img
+                  className="size-full object-cover"
+                  src={previewUrl}
+                  alt="Avatar preview"
+                  width={64}
+                  height={64}
+                  style={{ objectFit: "cover" }}
+                />
+              ) : (
+                <div aria-hidden="true">
+                  <CircleUserRoundIcon className="size-4 opacity-60" />
+                </div>
+              )}
+            </button>
+            {files.length > 0 && (
+              <Button
+                onClick={() => removeFile(files[0]?.id)}
+                size="icon"
+                className="border-background focus-visible:border-background absolute -top-1 -right-1 size-6 rounded-full border-2 shadow-none"
+                aria-label="Remove image"
+              >
+                <XIcon className="size-3.5" />
+              </Button>
+            )}
+            <input
+              {...getInputProps()}
+              className="sr-only"
+              aria-label="Upload image file"
+              tabIndex={-1}
+            />
+          </div>
+          {files.length > 0 && (
+            <Button
+              type="button"
+              size="sm"
+              onClick={() => uploadAvatarMutation.mutate()}
+              disabled={uploadAvatarMutation.isPending}
+            >
+              {uploadAvatarMutation.isPending && (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              )}
+              Save
+            </Button>
+          )}
+        </div>
         <div className="text-center sm:text-left">
           <h3 className="text-sm font-medium">Profile Picture</h3>
           <p className="text-muted-foreground mt-1 text-sm">

--- a/src/app/api/user/avatar/route.ts
+++ b/src/app/api/user/avatar/route.ts
@@ -47,6 +47,14 @@ export async function POST(req: NextRequest) {
     return new NextResponse("File not provided", { status: 400 });
   }
 
+  if (file.size > 5 * 1024 * 1024) {
+    return new NextResponse("File too large", { status: 400 });
+  }
+
+  if (!file.type.startsWith("image/")) {
+    return new NextResponse("Invalid file type", { status: 400 });
+  }
+
   const arrayBuffer = await file.arrayBuffer();
   const key = `uploads/${nanoid()}`;
 

--- a/src/client-actions/upload-avatar.ts
+++ b/src/client-actions/upload-avatar.ts
@@ -1,0 +1,16 @@
+export async function uploadAvatar(file: File) {
+  const formData = new FormData();
+  formData.append("file", file);
+
+  const res = await fetch("/api/user/avatar", {
+    method: "POST",
+    body: formData,
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(text || "Upload failed");
+  }
+
+  return res.json() as Promise<{ id: string; url: string }>;
+}


### PR DESCRIPTION
## Summary
- add upload avatar client action
- validate avatar size and type on upload API
- integrate avatar upload UI in settings profile form

## Testing
- `npm run lint` *(fails: React hook misuse and other issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68549d99df00833091b780379d3387cb